### PR TITLE
Refactor itertools

### DIFF
--- a/src/util/itertools.test.ts
+++ b/src/util/itertools.test.ts
@@ -47,7 +47,7 @@ describe('combinations: choose k of n without repitition', () => {
         desiredResult: [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]],
       },
     ])('case no. %#', ({k, pool, desiredResult}: TestCase) => {
-      const actualResult: number[][] = [...combinations(pool, k)];
+      const actualResult: number[][] = combinations(pool, k);
       expect(actualResult).toEqual(desiredResult);
     });
   });
@@ -58,7 +58,7 @@ describe('combinations: choose k of n without repitition', () => {
       1.3, // must be integer
       3,   // must be <= pool-size
     ])('choose k = %j', (k: number) => {
-      expect(() => [...combinations([1, 2], k)]).toThrow();
+      expect(() => combinations([1, 2], k)).toThrow();
     });
   });
 });
@@ -103,7 +103,7 @@ describe('combinationsWithRepitition: choose k of n with repitition', () => {
         ],
       },
     ])('case no. %#', ({k, pool, desiredResult}: TestCase) => {
-      const actualResult: number[][] = [...combinationsWithRepitition(pool, k)];
+      const actualResult: number[][] = combinationsWithRepitition(pool, k);
       expect(actualResult).toEqual(desiredResult);
     });
   });
@@ -114,7 +114,7 @@ describe('combinationsWithRepitition: choose k of n with repitition', () => {
       -1,  // must be >= 0
       1.3, // must be integer
     ])('choose k = %j', (k: number) => {
-      expect(() => [...combinationsWithRepitition([1, 2], k)]).toThrow();
+      expect(() => combinationsWithRepitition([1, 2], k)).toThrow();
     });
   });
 });

--- a/src/util/itertools.ts
+++ b/src/util/itertools.ts
@@ -4,10 +4,10 @@
 // they produce the combinations. This should be corrected.
 
 /**
- * Yield all k-combinations with repition from a given sequence.
+ * Return all k-combinations with repition from a given pool.
  *
- * For example if the iterable is the array [1,2,3,4] and k = 2 the resulting
- * generator yields all multi-subsequences of length 2:
+ * For example if the pool is the array [1, 2, 3, 4] and k = 2 the result are
+ * all multi-subarrays of length 2:
  *
  *   [1,1], [2,1], [3,1], [4,1], [2,2], [3,2], [4,2], [3,3], [4,3], [4,4].
  *
@@ -19,11 +19,10 @@
  * See also:
  * https://en.wikipedia.org/wiki/Combination#Number_of_combinations_with_repetition
  *
- * @param iterable A finite sequence
+ * @param pool A finite sequence
  * @param k The length of the combinations: 1, 2, 3, ...
  */
-export function* combinationsWithRepitition<T>(iterable: Iterable<T>, k: number) {
-  const pool = Array.from(iterable);
+export function combinationsWithRepitition<T>(pool: readonly T[], k: number) {
   const max_index = pool.length - 1;
 
   if (k < 0 || k % 1 !== 0) {
@@ -34,10 +33,11 @@ export function* combinationsWithRepitition<T>(iterable: Iterable<T>, k: number)
     throw new Error("If k is non-zero, iterable is not allowed to be empty.");
   }
 
+  const result: T[][] = [];
+
   const indices: number[] = Array.from(Array(k), () => 0);
   let next: T[] = indices.map(i => pool[i]);
-
-  yield next;
+  result.push(next);
 
   outerLoop:
   while (true) {
@@ -51,17 +51,17 @@ export function* combinationsWithRepitition<T>(iterable: Iterable<T>, k: number)
       indices[n] = current;
       next[n] = pool[current];
     }
-    yield next;
+    result.push(next);
   }
 
-  return;
+  return result;
 }
 
 /**
- * Yield all k-combinations from a given sequence .
+ * Return all k-combinations from a given sequence.
  *
- * For example if the iterable is the array [1,2,3,4] and k = 2 the resulting
- * generator yields all subsequences of length 2:
+ * For example if the pool is the array [1,2,3,4] and k = 2 the result are all
+ * subsequences of length 2:
  *
  *   [1,2], [1,3], [1,4], [2,3], [2,4], [3,4].
  *
@@ -79,20 +79,19 @@ export function* combinationsWithRepitition<T>(iterable: Iterable<T>, k: number)
  * See also:
  * https://en.wikipedia.org/wiki/Combination#Enumerating_k-combinations
  *
- * @param iterable A finite sequence
+ * @param pool A finite sequence
  * @param k The length of the combinations: 1, 2, 3, ...
  */
-export function* combinations<T>(iterable: Iterable<T>, k: number) {
-  // TODO it is not really helpfull to have an iterable as input
-  const pool = Array.from(iterable);
-
+export function combinations<T>(pool: readonly T[], k: number) {
   if (k > pool.length || k < 0 || k % 1 !== 0) {
-    throw new Error("k must be in {0, 1, 2, ..., n}, where n is the length of the iterable.");
+    throw new Error("k must be in {0, 1, 2, ..., n}, where n is the length of the pool.");
   }
+
+  const result: T[][] = [];
 
   const indices: number[] = Array.from({length: k}, (_, i) => i);
   let next: T[] = indices.map(i => pool[i]);
-  yield next;
+  result.push(next);
 
   while (true) {
     let n = k - 1;
@@ -105,6 +104,8 @@ export function* combinations<T>(iterable: Iterable<T>, k: number) {
       indices[n] = indices[n-1] + 1;
       next[n] = pool[indices[n]];
     }
-    yield next;
+    result.push(next);
   }
+
+  return result;
 }

--- a/src/util/itertools.ts
+++ b/src/util/itertools.ts
@@ -1,5 +1,10 @@
 /** Basic combinatorial utility. For internal use only. */
 
+import { Primitive } from "./util.js";
+
+// The combinations-functions below only allow primitive types as template
+// argument since we don't want to deal with deep copies.
+
 // TODO the two functions are inconsistent with respect to the order in which
 // they produce the combinations. This should be corrected.
 
@@ -22,7 +27,7 @@
  * @param pool A finite sequence
  * @param k The length of the combinations: 1, 2, 3, ...
  */
-export function combinationsWithRepitition<T>(pool: readonly T[], k: number) {
+export function combinationsWithRepitition<T extends Primitive>(pool: readonly T[], k: number) {
   const max_index = pool.length - 1;
 
   if (k < 0 || k % 1 !== 0) {
@@ -82,7 +87,7 @@ export function combinationsWithRepitition<T>(pool: readonly T[], k: number) {
  * @param pool A finite sequence
  * @param k The length of the combinations: 1, 2, 3, ...
  */
-export function combinations<T>(pool: readonly T[], k: number) {
+export function combinations<T extends Primitive>(pool: readonly T[], k: number) {
   if (k > pool.length || k < 0 || k % 1 !== 0) {
     throw new Error("k must be in {0, 1, 2, ..., n}, where n is the length of the pool.");
   }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,1 +1,3 @@
 export class RegressionError extends Error {}
+
+export type Primitive = string | number | boolean | bigint | symbol | undefined | null;


### PR DESCRIPTION
Simplify the interface of the `itertools` utility functions `combinations`, and `combinationsWithRepitition`. In particular we just use arrays instead of iterables and generators (which was overkill). Moreover we restrict the template parameter to primitive types since this prevents us from dealing with deep copies if we wanted a correct implemenation for object types.