### PR TITLE
Switch back to commonjs module

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,10 +5,6 @@ const config: Config.InitialOptions = {
     "<rootDir>/src"
   ],
   preset: "ts-jest",
-  moduleNameMapper: {
-    // Jest does not like the file extension ".js"
-    "(.+)\\.js": "$1"
-  },
   globals: {
     "ts-jest": {
       tsconfig: "tsconfig.test.json",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test": "jest --verbose",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf ./dist ./docs",
     "doc": "typedoc"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.3.0",
   "description": "JavaScript/TypeScript library for multivariate polynomial regression.",
   "main": "dist/index.js",
-  "type": "module",
   "scripts": {
     "test": "jest --verbose",
     "build": "tsc -p tsconfig.build.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { PolynomialRegressor } from './polynomial-regression.js'
-export { PolynomialFeatures } from './polynomial-features.js'
-export { RegressionError } from './util/util.js'
+export { PolynomialRegressor } from './polynomial-regression'
+export { PolynomialFeatures } from './polynomial-features'
+export { RegressionError } from './util/util'

--- a/src/polynomial-features.test.ts
+++ b/src/polynomial-features.test.ts
@@ -1,6 +1,6 @@
-import { PolynomialFeatures } from './index.js'
-import { RegressionError } from './util/util.js';
-import { PolynomialFeaturesConfig } from './polynomial-features.js';
+import { PolynomialFeatures } from './index'
+import { RegressionError } from './util/util';
+import { PolynomialFeaturesConfig } from './polynomial-features';
 
 /// Auxiliary function
 

--- a/src/polynomial-features.ts
+++ b/src/polynomial-features.ts
@@ -1,5 +1,5 @@
-import { combinations, combinationsWithRepitition } from './util/itertools.js'
-import { RegressionError } from './util/util.js'
+import { combinations, combinationsWithRepitition } from './util/itertools'
+import { RegressionError } from './util/util'
 
 /** For internal use only */
 export type PolynomialFeaturesConfig = { degree: number, homogeneous: boolean,

--- a/src/polynomial-regression.test.ts
+++ b/src/polynomial-regression.test.ts
@@ -1,7 +1,7 @@
-import { PolynomialRegressor } from './index.js'
+import { PolynomialRegressor } from './index'
 
-import * as data1 from '../data/example1.js'
-import * as data2 from '../data/example2.js'
+import * as data1 from '../data/example1'
+import * as data2 from '../data/example2'
 
 /// Auxiliary function
 
@@ -202,4 +202,3 @@ describe('Misc', () => {
     expectToBeCloseTo(ypredict, data1.testPredicted);
   });
 });
-

--- a/src/polynomial-regression.ts
+++ b/src/polynomial-regression.ts
@@ -1,7 +1,7 @@
 import { SVD, Matrix } from 'ml-matrix'
 
-import { PolynomialFeatures, PolynomialFeaturesConfig } from './polynomial-features.js'
-import { RegressionError } from './util/util.js';
+import { PolynomialFeatures, PolynomialFeaturesConfig } from './polynomial-features'
+import { RegressionError } from './util/util';
 
 /**
  * For internal use only

--- a/src/util/itertools.test.ts
+++ b/src/util/itertools.test.ts
@@ -1,4 +1,4 @@
-import { combinations, combinationsWithRepitition } from './itertools.js'
+import { combinations, combinationsWithRepitition } from './itertools'
 
 
 interface TestCase {

--- a/src/util/itertools.ts
+++ b/src/util/itertools.ts
@@ -1,6 +1,6 @@
 /** Basic combinatorial utility. For internal use only. */
 
-import { Primitive } from "./util.js";
+import { Primitive } from "./util";
 
 // The combinations-functions below only allow primitive types as template
 // argument since we don't want to deal with deep copies.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "target": "es2015",
-    "module": "es2015",
-    "moduleResolution": "node",
+    "module": "es2015",  // TODO
+    "moduleResolution": "node",  // "node" needed for some reason
     "declaration": true,
     "removeComments": false,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "target": "es2015",
-    "module": "es2015",  // TODO
+    "module": "commonjs",
     "moduleResolution": "node",  // "node" needed for some reason
     "declaration": true,
     "removeComments": false,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "esModuleInterop": true,
+    "esModuleInterop": true,  // https://devblogs.microsoft.com/typescript/announcing-typescript-2-7/#easier-ecmascript-module-interoperability
   },
 }


### PR DESCRIPTION
In v1.3.0 I switched to the esmodule format. This seems to cause many problems in some projects.

Version 1.3.0 seems to be avoided for that reason (as evidenced by npm statistics). Therefore I switch back to commonjs. An upgrade from v1.2.2 to a yet to be deployed v1.3.1 (skipping v1.3.0) should be painless.